### PR TITLE
fix: Initialize results variable to prevent UnboundLocalError

### DIFF
--- a/pr_review/main.py
+++ b/pr_review/main.py
@@ -56,6 +56,7 @@ class PRReviewSystem:
         Returns:
             Processing results
         """
+        results = {}
         try:
             logger.info(f"Processing PR #{pr_number} in {repo}")
             


### PR DESCRIPTION
## Description
This PR fixes a bug identified in Issue #53 where an `UnboundLocalError` occurs in `process_pull_request`.

Currently, the variable `results` is only assigned inside the analysis block. If the code execution skips that block, the code crashes when trying to reference `results` in the notification step.

## Fix
I have initialized `results = {}` at the start of the function. This ensures the variable is always bound, preventing the crash regardless of the execution path.

Closes #53