### PR TITLE
fix: resolve UnboundLocalError for 'results' variable in process_pull_request

### DIFF
--- a/pr_review/main.py
+++ b/pr_review/main.py
@@ -56,6 +56,14 @@ class PRReviewSystem:
         Returns:
             Processing results
         """
+        # Initialize results early to avoid UnboundLocalError
+        results = {
+            'pr_number': pr_number,
+            'repository': repo,
+            'status': 'error',
+            'error': 'Unknown error occurred'
+        }
+        
         try:
             logger.info(f"Processing PR #{pr_number} in {repo}")
             
@@ -105,10 +113,7 @@ class PRReviewSystem:
             
             self.github_client.create_issue_comment(repo, pr_number, comment_body)
             
-            # Send Discord notification
-            asyncio.create_task(self._send_discord_notification(results, comment_body))
-            
-            # Return processing results
+            # Update results with success data BEFORE sending notification
             results = {
                 'pr_number': pr_number,
                 'repository': repo,
@@ -118,6 +123,9 @@ class PRReviewSystem:
                 'ai_review_summary': ai_review.get('summary', ''),
                 'status': 'success'
             }
+            
+            # Send Discord notification with properly initialized results
+            asyncio.create_task(self._send_discord_notification(results, comment_body))
             
             logger.info(f"Successfully processed PR #{pr_number}")
             return results


### PR DESCRIPTION
## Summary
Fixes the `UnboundLocalError` where the `results` variable is referenced before assignment in the `process_pull_request()` method.

## Problem
The variable `results` was being passed to `_send_discord_notification()` before it was defined, causing an `UnboundLocalError` when exceptions occurred early in the processing pipeline.

## Solution
- Initialize `results` dictionary at the beginning of `process_pull_request()` with default error state
- Update `results` with success data before sending Discord notification
- Ensures `results` is always defined for both success and error paths

## Changes
- Added early initialization of `results` dict with default error values
- Moved `results` definition before the Discord notification call
- Maintained backward compatibility with existing error handling

## Testing
- Verified variable is accessible in all code paths
- Tested error scenarios to ensure proper error notification
- Confirmed success path still works correctly

## Related Issue
Fixes #53

## Impact
- Prevents runtime crashes from undefined variable
- Improves error handling reliability
- Better error reporting to Discord