### PR TITLE
chore: add pre-commit hooks for code quality enforcement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,61 @@
+repos:
+  # Python code formatting with black
+  - repo: https://github.com/psf/black
+    rev: 24.1.1
+    hooks:
+      - id: black
+        language_version: python3.13
+        args: ['--line-length=100']
+
+  # Import sorting with isort
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args: ['--profile', 'black', '--line-length', '100']
+
+  # Linting with flake8
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+        args: ['--max-line-length=100', '--extend-ignore=E203,W503']
+
+  # Security checks with bandit
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.6
+    hooks:
+      - id: bandit
+        args: ['-c', 'pyproject.toml']
+        additional_dependencies: ['bandit[toml]']
+
+  # Type checking with mypy
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy
+        additional_dependencies: [types-all]
+        args: ['--ignore-missing-imports', '--no-strict-optional']
+
+  # General file checks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+        args: ['--maxkb=1000']
+      - id: check-json
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: debug-statements
+      - id: mixed-line-ending
+
+  # Docstring checks
+  - repo: https://github.com/PyCQA/pydocstyle
+    rev: 6.3.0
+    hooks:
+      - id: pydocstyle
+        args: ['--convention=google']
+        exclude: 'test_.*\.py$'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,41 @@
+[tool.black]
+line-length = 100
+target-version = ['py313']
+include = '\.pyi?$'
+extend-exclude = '''
+/(
+  # directories
+  \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | build
+  | dist
+)/
+'''
+
+[tool.isort]
+profile = "black"
+line_length = 100
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+
+[tool.bandit]
+exclude_dirs = ["tests", "test"]
+skips = ["B101", "B601"]
+
+[tool.mypy]
+python_version = "3.13"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = false
+ignore_missing_imports = true
+
+[tool.pydocstyle]
+convention = "google"
+add_ignore = ["D100", "D104"]


### PR DESCRIPTION
## Summary
Adds comprehensive pre-commit hooks to enforce code quality standards automatically before commits.

## Changes
### `.pre-commit-config.yaml`
- **Black**: Automatic code formatting (100 char line length)
- **isort**: Import statement organization
- **flake8**: Linting and style checks
- **bandit**: Security vulnerability scanning
- **mypy**: Static type checking
- **Standard checks**: Trailing whitespace, EOF, YAML/JSON validation, large files
- **pydocstyle**: Docstring conventions (Google style)

### `pyproject.toml`
- Centralized configuration for all tools
- Black, isort, bandit, mypy, and pydocstyle settings
- Consistent behavior across all contributors

## Benefits
- ✅ Catches issues before commit, not in CI
- ✅ Ensures consistent code style across contributors
- ✅ Reduces review time by automating style checks
- ✅ Improves code security with bandit scans
- ✅ Enforces type safety with mypy
- ✅ Maintains docstring quality

## Setup Instructions
```bash
pip install pre-commit
pre-commit install
```

## Testing
- All hooks tested with existing codebase
- Configuration validated against Python 3.13
- Compatible with existing CI/CD workflows

## Impact
- Improves code quality automatically
- Reduces manual review burden
- Catches bugs earlier in development cycle
- Standardizes code style across team