### PR TITLE
feat(readme): add Python version requirements and installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,82 @@
 
 ---
 
+## Prerequisites
+
+### Python Version Requirements
+This project requires **Python 3.13+** due to the `audioop-lts` dependency used by discord.py voice features.
+
+#### Check your Python version:
+```bash
+python3 --version
+# or
+python --version
+```
+
+#### Install Python 3.13+ if needed:
+
+**macOS (using Homebrew):**
+```bash
+brew install python@3.13
+```
+
+**Ubuntu/Debian:**
+```bash
+sudo apt update
+sudo apt install software-properties-common
+sudo add-apt-repository ppa:deadsnakes/ppa
+sudo apt update
+sudo apt install python3.13 python3.13-venv python3.13-dev
+```
+
+**Windows:**
+Download Python 3.13+ from [python.org](https://www.python.org/downloads/)
+
+### Installation
+
+1. **Clone the repository:**
+```bash
+git clone https://github.com/ruxailab/disgitbot.git
+cd disgitbot
+```
+
+2. **Create a virtual environment with Python 3.13+:**
+```bash
+python3.13 -m venv venv
+# or if python3.13 is your default:
+python -m venv venv
+```
+
+3. **Activate the virtual environment:**
+```bash
+# macOS/Linux:
+source venv/bin/activate
+# Windows:
+venv\Scripts\activate
+```
+
+4. **Install dependencies:**
+```bash
+pip install -r discord_bot/config/discord_bot_requirements.txt
+```
+
+### Alternative Installation (if Python 3.13+ is not available)
+
+If you cannot install Python 3.13+, you can try installing without voice support:
+
+```bash
+# Install discord.py without voice support
+pip install discord.py==2.0.0 --no-deps
+pip install aiohttp
+pip install python-dotenv==1.0.0
+pip install firebase-admin==6.7.0
+# Add other dependencies as needed
+```
+
+**Note:** Voice features will not be available without `audioop-lts`.
+
+---
+
 ## Project Overview
 
 The Disgitbot project aims to create a comprehensive Discord bot that integrates GitHub activity with Discord communities, providing real-time notifications, contribution analytics, and automated workflow management. The project focuses on enhancing community engagement and streamlining development workflows through intelligent automation.


### PR DESCRIPTION
Fixed #19 

1. Python Version Requirements Section
- Added explicit Python 3.13+ requirement explanation
- Included command to check current Python version
- Explained the dependency relationship with audioop-lts and discord.py voice features
2. Multi-Platform Installation Instructions
- macOS: Added Homebrew installation command for Python 3.13
- Ubuntu/Debian: Provided step-by-step instructions using deadsnakes PPA
- Windows: Referenced official Python.org download
3. Virtual Environment Setup
- Added proper virtual environment creation with Python 3.13
- Included activation commands for different operating systems
- Ensured dependency isolation and version compatibility
4. Alternative Installation Path
- Provided fallback installation method for users unable to upgrade Python
- Explained how to install discord.py without voice support
- Listed manual dependency installation as workaround
- Added clear warning about limited functionality without audioop-lts
